### PR TITLE
Fix build script for MacOSX, and add notes documenting future

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -14,14 +14,14 @@ Clone the OpenCilk compiler, runtime, and productivity tool repositories.  The
 Cheetah runtime and OpenCilk tool repositories must be cloned into
 sub-directories of the OpenCilk project directory:
 
-    git clone -b opencilk/v1.0-rc2 --single-branch https://github.com/OpenCilk/opencilk-project
-    git clone -b opencilk/v1.0-rc2 https://github.com/OpenCilk/cheetah opencilk-project/cheetah
-    git clone -b opencilk/v1.0-rc2 https://github.com/OpenCilk/productivity-tools opencilk-project/cilktools
+    git clone -b opencilk/v1.0-rc3 --single-branch https://github.com/OpenCilk/opencilk-project
+    git clone -b opencilk/v1.0-rc3 https://github.com/OpenCilk/cheetah opencilk-project/cheetah
+    git clone -b opencilk/v1.0-rc3 https://github.com/OpenCilk/productivity-tools opencilk-project/cilktools
 
 Clone the OpenCilk infrastructure repository, which contains the OpenCilk build
 script:
 
-    git clone -b opencilk/v1.0-rc2 https://github.com/OpenCilk/infrastructure
+    git clone -b opencilk/v1.0-rc3 https://github.com/OpenCilk/infrastructure
 
 ### Building OpenCilk
 

--- a/tools/build
+++ b/tools/build
@@ -71,15 +71,34 @@ cd "${BUILD_DIR}"
 
 : "${OPENCILK_RELEASE:=Release}" # RelWithDebInfo to debug the compiler
 : "${OPENCILK_ASSERTIONS:=On}"   # Off to disable assertions in the compiler
-COMPONENTS="clang;compiler-rt"   # Required components; edit to add extra LLVM projects
+OPENCILK_COMPONENTS="clang"      # Required components; edit to add extra LLVM projects
+OPENCILK_RUNTIMES="cheetah;cilktools" # Required runtimes
+# Add compiler-rt project to enable support for Google sanitizers.
 case "${OS}" in
     Darwin)
-        : "${LIBCXX:="libcxx;"}" ;;
+        : "${COMPILER_RT_RUNTIMES:=";compiler-rt;libcxx"}" ;;
+    *)
+        : "${COMPILER_RT_COMPONENTS:=";compiler-rt"}" ;;
 esac
-RUNTIMES="${LIBCXX}cheetah;cilktools" # Required runtimes
+# TODO: Add support to optionally enable other popular features on
+# systems that support them.  Some example features include:
+#  - LLD, enabled by adding `lld` to the COMPONENTS list.
+#  - LLDB, enabled by adding `lldb` to the COMPONENTS list.
+#  - gold-linker support, enabled by passing the additional flag
+#  `-DLLVM_BINUTILS_INCDIR=<path>` to cmake, where `<path>/plugin-api.h`
+#  exists.  Typically, `<path>` is `/usr/include` on systems that have
+#  the GNU BFD development files installed.
+COMPONENTS="${OPENCILK_COMPONENTS}${COMPILER_RT_COMPONENTS}"
+RUNTIMES="${OPENCILK_RUNTIMES}${COMPILER_RT_RUNTIMES}"
 
+# Note: We restrict the build to enable only architecture targets on
+# the host (via -DLLVM_TARGETS_TO_BUILD=host) in order to work around
+# an issue with recent versions of MacOSX and XCode trying to enable
+# ARM support (c.f., https://trac.macports.org/ticket/61555).  This
+# build restriction also reduces the overall build size.
 cmake -DLLVM_ENABLE_PROJECTS="${COMPONENTS}" \
       -DLLVM_ENABLE_RUNTIMES="${RUNTIMES}" \
+      -DLLVM_TARGETS_TO_BUILD=host \
       -DLLVM_ENABLE_ASSERTIONS="${OPENCILK_ASSERTIONS:?}" \
       -DCMAKE_BUILD_TYPE="${OPENCILK_RELEASE:?}" \
       "${OPENCILK_SOURCE}/llvm"
@@ -88,7 +107,11 @@ cmake -DLLVM_ENABLE_PROJECTS="${COMPONENTS}" \
 cmake --build . -- -j "${NCPU}"
 # TODO: cmake --install ...
 
-TRIPLE=$("${BUILD_DIR}/bin/clang" -print-target-triple)
+case "${OS}" in
+    # Darwin is a special case.  The version is not embedded in the path.
+    Darwin) TRIPLE=darwin ;; # special case
+    *) TRIPLE=$("${BUILD_DIR}/bin/clang" -print-target-triple);;
+esac
 VERSION=$(sed -n '/set.PACKAGE_VERSION/s/^.* \([0-9.]*\))/\1/p' "${CHEETAH_SOURCE}/CMakeLists.txt")
 
 LIBPATH="${BUILD_DIR}/lib/clang/${VERSION}/lib/${TRIPLE}/libopencilk.a"


### PR DESCRIPTION
build-script changes.

Darwin current has a unique naming system for library directories

Co-authored-by: John F. Carr <jfc@mit.edu>